### PR TITLE
additional CLI control knobs and multi-frame graph collection

### DIFF
--- a/built/brave/crawl.js
+++ b/built/brave/crawl.js
@@ -19,7 +19,11 @@ const setupEnv = (args) => {
     const logger = getLogger(args);
     const platformName = osLib.platform();
     let closeFunc;
-    if (xvfbPlatforms.has(platformName)) {
+    if (args.interactive) {
+        logger.debug('Interactive mode, skipping Xvfb');
+        closeFunc = () => { };
+    }
+    else if (xvfbPlatforms.has(platformName)) {
         logger.debug(`Running on ${platformName}, starting Xvfb`);
         const xvfbHandle = new Xvbf();
         xvfbHandle.startSync();
@@ -48,6 +52,9 @@ export const graphForUrl = (args, url) => __awaiter(void 0, void 0, void 0, func
         logger.debug('Launching puppeteer with args: ', puppeteerArgs);
         const browser = yield puppeteerLib.launch(puppeteerArgs);
         const page = yield browser.newPage();
+        if (args.userAgent) {
+            yield page.setUserAgent(args.userAgent);
+        }
         logger.debug(`Navigating to ${url}`);
         yield page.goto(url);
         const waitTimeMs = args.seconds * 1000;

--- a/built/brave/crawl.js
+++ b/built/brave/crawl.js
@@ -10,6 +10,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 import * as osLib from 'os';
 import fsExtraLib from 'fs-extra';
+import pathLib from 'path';
 import puppeteerLib from 'puppeteer-core';
 import Xvbf from 'xvfb';
 import { getLogger } from './debug.js';
@@ -43,42 +44,93 @@ const setupEnv = (args) => {
 const isNotHTMLPageGraphError = (error) => {
     return error.message.indexOf('No Page Graph for this Document') >= 0;
 };
-export const graphForUrl = (args, url) => __awaiter(void 0, void 0, void 0, function* () {
+const isSessionClosedError = (error) => {
+    return error.message.indexOf('Session closed. Most likely the page has been closed.') >= 0;
+};
+export const writeGraphsForCrawl = (args) => __awaiter(void 0, void 0, void 0, function* () {
     const logger = getLogger(args);
+    const url = args.urls[0];
     const { puppeteerArgs, pathForProfile, shouldClean } = puppeteerConfigForArgs(args);
     const envHandle = setupEnv(args);
-    let pageGraphText;
     try {
         logger.debug('Launching puppeteer with args: ', puppeteerArgs);
         const browser = yield puppeteerLib.launch(puppeteerArgs);
-        const page = yield browser.newPage();
-        if (args.userAgent) {
-            yield page.setUserAgent(args.userAgent);
-        }
-        logger.debug(`Navigating to ${url}`);
-        yield page.goto(url);
-        const waitTimeMs = args.seconds * 1000;
-        logger.debug(`Waiting for ${waitTimeMs}ms`);
-        yield page.waitFor(waitTimeMs);
         try {
-            logger.debug('Requesting PageGraph data');
-            const client = yield page.target().createCDPSession();
-            const pageGraphRs = yield client.send('Page.generatePageGraph');
-            pageGraphText = pageGraphRs.data;
-            logger.debug(`Received response of length: ${pageGraphText.length}`);
-        }
-        catch (error) {
-            if (isNotHTMLPageGraphError(error)) {
-                const currentUrl = page.url();
-                logger.debug(`Was not able to fetch PageGraph data for ${currentUrl}`);
-                throw new Error(`Wrong protocol for ${url}`);
+            // turn target-crashed events (e.g., a page or remote iframe crashed) into crawl-fatal errors
+            const bcdp = yield browser.target().createCDPSession();
+            bcdp.on('Target.targetCrashed', (event) => {
+                logger.debug(`ERROR Target.targetCrashed { targetId: ${event.targetId}, status: "${event.status}", errorCode: ${event.errorCode} }`);
+                throw new Error(event.status);
+            });
+            // track frame IDs to provide sequence numbers (root frame IDs last longer than individual documents)
+            const frameCounts = Object.create(null);
+            const nextFrameSeq = (frameId) => {
+                const seqNum = frameCounts[frameId] = (frameId in frameCounts ? frameCounts[frameId] : -1) + 1;
+                return seqNum;
+            };
+            // track the creation/destruction of page targets and listen for PG data events on each new page
+            const pageMap = new Map();
+            browser.on('targetcreated', (target) => __awaiter(void 0, void 0, void 0, function* () {
+                if (target.type() === 'page') {
+                    const page = yield target.page();
+                    pageMap.set(target, page);
+                    // On PG data event, write to frame-id-tagged GraphML file in output directory
+                    const client = yield target.createCDPSession();
+                    client.on('Page.finalPageGraph', (event) => {
+                        logger.debug(`finalpageGraph { frameId: ${event.frameId}, size: ${event.data.length}}`);
+                        const seqNum = nextFrameSeq(event.frameId);
+                        const outputFilename = pathLib.join(args.outputPath, `page_graph_${event.frameId}.${seqNum}.graphml`);
+                        fsExtraLib.writeFile(outputFilename, event.data).catch((err) => {
+                            console.error('ERROR saving Page.finalPageGraph output:', err);
+                        });
+                    });
+                }
+            }));
+            browser.on('targetdestroyed', (target) => __awaiter(void 0, void 0, void 0, function* () {
+                if (target.type() === 'page') {
+                    pageMap.delete(target);
+                }
+            }));
+            // create new page, update UA if needed, navigate to target URL, and wait for idle time
+            const page = yield browser.newPage();
+            if (args.userAgent) {
+                yield page.setUserAgent(args.userAgent);
             }
-            throw error;
+            logger.debug(`Navigating to ${url}`);
+            yield page.goto(url);
+            const waitTimeMs = args.seconds * 1000;
+            logger.debug(`Waiting for ${waitTimeMs}ms`);
+            yield page.waitFor(waitTimeMs);
+            // tear down by navigating all open pages to about:blank (to force PG data flushes)
+            try {
+                yield Promise.all(Array.from(pageMap.values()).map((page /* puppeteer Page */) => page.goto('about:blank')));
+            }
+            catch (error) {
+                if (isSessionClosedError(error)) {
+                    logger.debug('WARNING: session dropped (page unexpectedly closed?)');
+                    // EAT IT and carry on
+                }
+                else if (isNotHTMLPageGraphError(error)) {
+                    logger.debug('WARNING: was not able to fetch PageGraph data from target');
+                    // EAT IT and carry on
+                }
+                else {
+                    logger.debug('ERROR flushing PageGraph data:', error);
+                    throw error;
+                }
+            }
+            yield page.close();
+        }
+        catch (err) {
+            console.error('ERROR runtime fiasco from browser/page:', err);
         }
         finally {
             logger.debug('Closing the browser');
             yield browser.close();
         }
+    }
+    catch (err) {
+        console.error('ERROR runtime fiasco from infrastructure:', err);
     }
     finally {
         envHandle.close();
@@ -86,13 +138,4 @@ export const graphForUrl = (args, url) => __awaiter(void 0, void 0, void 0, func
             fsExtraLib.remove(pathForProfile);
         }
     }
-    return pageGraphText;
-});
-export const writeGraphsForCrawl = (args) => __awaiter(void 0, void 0, void 0, function* () {
-    const logger = getLogger(args);
-    const url = args.urls[0];
-    const pageGraphText = yield graphForUrl(args, url);
-    logger.debug(`Writing result to ${args.outputPath}`);
-    yield fsExtraLib.writeFile(args.outputPath, pageGraphText);
-    return 1;
 });

--- a/built/brave/puppeteer.js
+++ b/built/brave/puppeteer.js
@@ -45,5 +45,14 @@ export const puppeteerConfigForArgs = (args) => {
         puppeteerArgs.args.push('--enable-logging');
         puppeteerArgs.args.push('--v=0');
     }
+    if (args.proxyServer) {
+        puppeteerArgs.args.push(`--proxy-server=${args.proxyServer.toString()}`);
+        if (args.proxyServer.protocol === 'socks5') {
+            puppeteerArgs.args.push(`--host-resolver-rules=MAP * ~NOTFOUND , EXCLUDE ${args.proxyServer.hostname}`);
+        }
+    }
+    if (args.extraArgs) {
+        puppeteerArgs.args.push(...args.extraArgs);
+    }
     return { puppeteerArgs, pathForProfile, shouldClean };
 };

--- a/built/brave/validate.js
+++ b/built/brave/validate.js
@@ -54,6 +54,8 @@ export const validate = (rawArgs) => {
     }
     const urls = passedUrlArgs;
     const secs = rawArgs.secs;
+    const interactive = rawArgs.interactive;
+    const userAgent = rawArgs.user_agent;
     const validatedArgs = {
         executablePath,
         outputPath,
@@ -62,8 +64,26 @@ export const validate = (rawArgs) => {
         withShieldsUp: (rawArgs.shields === 'up'),
         debugLevel: rawArgs.debug,
         existingProfilePath: undefined,
-        persistProfilePath: undefined
+        persistProfilePath: undefined,
+        interactive,
+        userAgent
     };
+    if (rawArgs.proxy_server) {
+        try {
+            validatedArgs.proxyServer = new URL(rawArgs.proxy_server);
+        }
+        catch (err) {
+            return [false, `invalid proxy-server: ${err.toString()}`];
+        }
+    }
+    if (rawArgs.extra_args) {
+        try {
+            validatedArgs.extraArgs = JSON.parse(rawArgs.extra_args);
+        }
+        catch (err) {
+            return [false, `invalid JSON array of extra-args: ${err.toString()}`];
+        }
+    }
     if (rawArgs.existing_profile && rawArgs.persist_profile) {
         return [false, 'Cannot specify both that you want to use an existing ' +
                 'profile, and that you want to persist a new profile.'];

--- a/built/brave/validate.js
+++ b/built/brave/validate.js
@@ -27,16 +27,6 @@ const isDir = (path) => {
     }
     return false;
 };
-const looksWriteable = (path) => {
-    const pathDir = pathLib.dirname(path);
-    if (!isDir(pathDir)) {
-        return false;
-    }
-    if (isDir(path)) {
-        return false;
-    }
-    return true;
-};
 export const validate = (rawArgs) => {
     const logger = getLoggerForLevel(rawArgs.debug);
     logger.debug('Received arguments: ', rawArgs);
@@ -44,7 +34,7 @@ export const validate = (rawArgs) => {
         return [false, `Invalid path to Brave binary: ${rawArgs.binary}`];
     }
     const executablePath = rawArgs.binary;
-    if (!looksWriteable(rawArgs.output)) {
+    if (!isDir(rawArgs.output)) {
         return [false, `Invalid path to write results to: ${rawArgs.output}`];
     }
     const outputPath = rawArgs.output;

--- a/built/run.js
+++ b/built/run.js
@@ -15,7 +15,7 @@ parser.addArgument(['-b', '--binary'], {
     help: 'Path to the PageGraph enabled build of Brave.'
 });
 parser.addArgument(['-o', '--output'], {
-    help: 'Path to write graphs to.',
+    help: 'Path (directory) to write graphs to.',
     required: true
 });
 parser.addArgument(['-u', '--url'], {

--- a/built/run.js
+++ b/built/run.js
@@ -48,6 +48,23 @@ parser.addArgument(['--debug'], {
     choices: ['none', 'debug', 'verbose'],
     defaultValue: defaultDebugSetting
 });
+parser.addArgument(['-i', '--interactive'], {
+    help: 'Suppress use of Xvfb to allow interaction with spawned browser instance',
+    action: 'storeTrue',
+    defaultValue: false
+});
+parser.addArgument(['-a', '--user-agent'], {
+    help: 'Override the browser\'s UserAgent string to USER_AGENT',
+    metavar: 'USER_AGENT'
+});
+parser.addArgument(['--proxy-server'], {
+    help: 'Use an HTTP/SOCKS proxy at URL for all navigations',
+    metavar: 'URL'
+});
+parser.addArgument(['-x', '--extra-args'], {
+    help: 'Pass JSON_ARRAY as extra CLI argument to the browser instance launched',
+    metavar: 'JSON_ARRAY'
+});
 const rawArgs = parser.parseArgs();
 const [isValid, errorOrArgs] = validate(rawArgs);
 if (!isValid) {

--- a/src/brave/crawl.ts
+++ b/src/brave/crawl.ts
@@ -17,7 +17,10 @@ const setupEnv = (args: CrawlArgs): EnvHandle => {
 
   let closeFunc
 
-  if (xvfbPlatforms.has(platformName)) {
+  if (args.interactive) {
+    logger.debug('Interactive mode, skipping Xvfb')
+    closeFunc = () => { }
+  } else if (xvfbPlatforms.has(platformName)) {
     logger.debug(`Running on ${platformName}, starting Xvfb`)
     const xvfbHandle = new Xvbf()
     xvfbHandle.startSync()
@@ -50,6 +53,10 @@ export const graphForUrl = async (args: CrawlArgs, url: Url): Promise<string> =>
     logger.debug('Launching puppeteer with args: ', puppeteerArgs)
     const browser = await puppeteerLib.launch(puppeteerArgs)
     const page = await browser.newPage()
+
+    if (args.userAgent) {
+      await page.setUserAgent(args.userAgent)
+    }
 
     logger.debug(`Navigating to ${url}`)
     await page.goto(url)

--- a/src/brave/crawl.ts
+++ b/src/brave/crawl.ts
@@ -3,6 +3,7 @@
 import * as osLib from 'os'
 
 import fsExtraLib from 'fs-extra'
+import pathLib from 'path'
 import puppeteerLib from 'puppeteer-core'
 import Xvbf from 'xvfb'
 
@@ -42,47 +43,99 @@ const isNotHTMLPageGraphError = (error: Error): boolean => {
   return error.message.indexOf('No Page Graph for this Document') >= 0
 }
 
-export const graphForUrl = async (args: CrawlArgs, url: Url): Promise<string> => {
+const isSessionClosedError = (error: Error): boolean => {
+  return error.message.indexOf('Session closed. Most likely the page has been closed.') >= 0
+}
+
+export const writeGraphsForCrawl = async (args: CrawlArgs): Promise<void> => {
   const logger = getLogger(args)
+  const url: Url = args.urls[0]
+
   const { puppeteerArgs, pathForProfile, shouldClean } = puppeteerConfigForArgs(args)
 
   const envHandle = setupEnv(args)
-  let pageGraphText: string
 
   try {
     logger.debug('Launching puppeteer with args: ', puppeteerArgs)
     const browser = await puppeteerLib.launch(puppeteerArgs)
-    const page = await browser.newPage()
-
-    if (args.userAgent) {
-      await page.setUserAgent(args.userAgent)
-    }
-
-    logger.debug(`Navigating to ${url}`)
-    await page.goto(url)
-
-    const waitTimeMs = args.seconds * 1000
-    logger.debug(`Waiting for ${waitTimeMs}ms`)
-    await page.waitFor(waitTimeMs)
-
     try {
-      logger.debug('Requesting PageGraph data')
-      const client = await page.target().createCDPSession()
-      const pageGraphRs = await client.send('Page.generatePageGraph')
-      pageGraphText = pageGraphRs.data
-      logger.debug(`Received response of length: ${pageGraphText.length}`)
-    } catch (error) {
-      if (isNotHTMLPageGraphError(error)) {
-        const currentUrl = page.url()
-        logger.debug(`Was not able to fetch PageGraph data for ${currentUrl}`)
-        throw new Error(`Wrong protocol for ${url}`)
+      // turn target-crashed events (e.g., a page or remote iframe crashed) into crawl-fatal errors
+      const bcdp = await browser.target().createCDPSession()
+      bcdp.on('Target.targetCrashed', (event: TargetCrashedEvent) => {
+        logger.debug(`ERROR Target.targetCrashed { targetId: ${event.targetId}, status: "${event.status}", errorCode: ${event.errorCode} }`)
+        throw new Error(event.status)
+      })
+
+      // track frame IDs to provide sequence numbers (root frame IDs last longer than individual documents)
+      const frameCounts = Object.create(null)
+      const nextFrameSeq = (frameId: string) => {
+        const seqNum = frameCounts[frameId] = (frameId in frameCounts ? frameCounts[frameId] : -1) + 1
+        return seqNum
       }
 
-      throw error
+      // track the creation/destruction of page targets and listen for PG data events on each new page
+      const pageMap = new Map()
+      browser.on('targetcreated', async (target: any) => {
+        if (target.type() === 'page') {
+          const page = await target.page()
+          pageMap.set(target, page)
+
+          // On PG data event, write to frame-id-tagged GraphML file in output directory
+          const client = await target.createCDPSession()
+          client.on('Page.finalPageGraph', (event: FinalPageGraphEvent) => {
+            logger.debug(`finalpageGraph { frameId: ${event.frameId}, size: ${event.data.length}}`)
+            const seqNum = nextFrameSeq(event.frameId)
+            const outputFilename = pathLib.join(args.outputPath, `page_graph_${event.frameId}.${seqNum}.graphml`)
+            fsExtraLib.writeFile(outputFilename, event.data).catch((err: Error) => {
+              console.error('ERROR saving Page.finalPageGraph output:', err)
+            })
+          })
+        }
+      })
+      browser.on('targetdestroyed', async (target: any) => {
+        if (target.type() === 'page') {
+          pageMap.delete(target)
+        }
+      })
+
+      // create new page, update UA if needed, navigate to target URL, and wait for idle time
+      const page = await browser.newPage()
+
+      if (args.userAgent) {
+        await page.setUserAgent(args.userAgent)
+      }
+
+      logger.debug(`Navigating to ${url}`)
+      await page.goto(url)
+
+      const waitTimeMs = args.seconds * 1000
+      logger.debug(`Waiting for ${waitTimeMs}ms`)
+      await page.waitFor(waitTimeMs)
+
+      // tear down by navigating all open pages to about:blank (to force PG data flushes)
+      try {
+        await Promise.all(Array.from(pageMap.values()).map((page: any /* puppeteer Page */) => page.goto('about:blank')))
+      } catch (error) {
+        if (isSessionClosedError(error)) {
+          logger.debug('WARNING: session dropped (page unexpectedly closed?)')
+        // EAT IT and carry on
+        } else if (isNotHTMLPageGraphError(error)) {
+          logger.debug('WARNING: was not able to fetch PageGraph data from target')
+        // EAT IT and carry on
+        } else {
+          logger.debug('ERROR flushing PageGraph data:', error)
+          throw error
+        }
+      }
+      await page.close()
+    } catch (err) {
+      console.error('ERROR runtime fiasco from browser/page:', err)
     } finally {
       logger.debug('Closing the browser')
       await browser.close()
     }
+  } catch (err) {
+    console.error('ERROR runtime fiasco from infrastructure:', err)
   } finally {
     envHandle.close()
 
@@ -90,15 +143,4 @@ export const graphForUrl = async (args: CrawlArgs, url: Url): Promise<string> =>
       fsExtraLib.remove(pathForProfile)
     }
   }
-
-  return pageGraphText
-}
-
-export const writeGraphsForCrawl = async (args: CrawlArgs): Promise<number> => {
-  const logger = getLogger(args)
-  const url: Url = args.urls[0]
-  const pageGraphText = await graphForUrl(args, url)
-  logger.debug(`Writing result to ${args.outputPath}`)
-  await fsExtraLib.writeFile(args.outputPath, pageGraphText)
-  return 1
 }

--- a/src/brave/puppeteer.ts
+++ b/src/brave/puppeteer.ts
@@ -56,5 +56,16 @@ export const puppeteerConfigForArgs = (args: CrawlArgs): any => {
     puppeteerArgs.args.push('--v=0')
   }
 
+  if (args.proxyServer) {
+    puppeteerArgs.args.push(`--proxy-server=${args.proxyServer.toString()}`)
+    if (args.proxyServer.protocol === 'socks5') {
+      puppeteerArgs.args.push(`--host-resolver-rules=MAP * ~NOTFOUND , EXCLUDE ${args.proxyServer.hostname}`)
+    }
+  }
+
+  if (args.extraArgs) {
+    puppeteerArgs.args.push(...args.extraArgs)
+  }
+
   return { puppeteerArgs, pathForProfile, shouldClean }
 }

--- a/src/brave/validate.ts
+++ b/src/brave/validate.ts
@@ -67,8 +67,10 @@ export const validate = (rawArgs: any): ValidationResult => {
   }
   const urls: Url[] = passedUrlArgs
   const secs: number = rawArgs.secs
+  const interactive: boolean = rawArgs.interactive
+  const userAgent: string | undefined = rawArgs.user_agent
 
-  const validatedArgs = {
+  const validatedArgs: CrawlArgs = {
     executablePath,
     outputPath,
     urls,
@@ -76,7 +78,25 @@ export const validate = (rawArgs: any): ValidationResult => {
     withShieldsUp: (rawArgs.shields === 'up'),
     debugLevel: rawArgs.debug,
     existingProfilePath: undefined,
-    persistProfilePath: undefined
+    persistProfilePath: undefined,
+    interactive,
+    userAgent
+  }
+
+  if (rawArgs.proxy_server) {
+    try {
+      validatedArgs.proxyServer = new URL(rawArgs.proxy_server)
+    } catch (err) {
+      return [false, `invalid proxy-server: ${err.toString()}`]
+    }
+  }
+
+  if (rawArgs.extra_args) {
+    try {
+      validatedArgs.extraArgs = JSON.parse(rawArgs.extra_args)
+    } catch (err) {
+      return [false, `invalid JSON array of extra-args: ${err.toString()}`]
+    }
   }
 
   if (rawArgs.existing_profile && rawArgs.persist_profile) {

--- a/src/brave/validate.ts
+++ b/src/brave/validate.ts
@@ -34,19 +34,6 @@ const isDir = (path: string): boolean => {
   return false
 }
 
-const looksWriteable = (path: string): boolean => {
-  const pathDir = pathLib.dirname(path)
-  if (!isDir(pathDir)) {
-    return false
-  }
-
-  if (isDir(path)) {
-    return false
-  }
-
-  return true
-}
-
 export const validate = (rawArgs: any): ValidationResult => {
   const logger = getLoggerForLevel(rawArgs.debug)
   logger.debug('Received arguments: ', rawArgs)
@@ -56,7 +43,7 @@ export const validate = (rawArgs: any): ValidationResult => {
   }
   const executablePath: FilePath = rawArgs.binary
 
-  if (!looksWriteable(rawArgs.output)) {
+  if (!isDir(rawArgs.output)) {
     return [false, `Invalid path to write results to: ${rawArgs.output}`]
   }
   const outputPath: FilePath = rawArgs.output

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,5 +1,6 @@
 declare module 'argparse'
 declare module 'fs-extra'
+declare module 'path'
 declare module 'puppeteer-core'
 declare module 'tmp'
 declare module 'xvfb'
@@ -41,4 +42,15 @@ interface TearDownEnvFunc {
 
 interface EnvHandle {
   close: TearDownEnvFunc
+}
+
+interface TargetCrashedEvent {
+  targetId: string,
+  status: string,
+  errorCode: number
+}
+
+interface FinalPageGraphEvent {
+  frameId: string,
+  data: string
 }

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -17,7 +17,11 @@ interface CrawlArgs {
   debugLevel: DebugLevel,
   seconds: number,
   existingProfilePath?: FilePath,
-  persistProfilePath?: FilePath
+  persistProfilePath?: FilePath,
+  interactive: boolean,
+  userAgent?: string,
+  proxyServer?: URL,
+  extraArgs?: string[]
 }
 
 type ValidationResult = [boolean, CrawlArgs | ErrorMsg]

--- a/src/run.ts
+++ b/src/run.ts
@@ -19,7 +19,7 @@ parser.addArgument(['-b', '--binary'], {
   help: 'Path to the PageGraph enabled build of Brave.'
 })
 parser.addArgument(['-o', '--output'], {
-  help: 'Path to write graphs to.',
+  help: 'Path (directory) to write graphs to.',
   required: true
 })
 parser.addArgument(['-u', '--url'], {

--- a/src/run.ts
+++ b/src/run.ts
@@ -52,6 +52,23 @@ parser.addArgument(['--debug'], {
   choices: ['none', 'debug', 'verbose'],
   defaultValue: defaultDebugSetting
 })
+parser.addArgument(['-i', '--interactive'], {
+  help: 'Suppress use of Xvfb to allow interaction with spawned browser instance',
+  action: 'storeTrue',
+  defaultValue: false
+})
+parser.addArgument(['-a', '--user-agent'], {
+  help: 'Override the browser\'s UserAgent string to USER_AGENT',
+  metavar: 'USER_AGENT'
+})
+parser.addArgument(['--proxy-server'], {
+  help: 'Use an HTTP/SOCKS proxy at URL for all navigations',
+  metavar: 'URL'
+})
+parser.addArgument(['-x', '--extra-args'], {
+  help: 'Pass JSON_ARRAY as extra CLI argument to the browser instance launched',
+  metavar: 'JSON_ARRAY'
+})
 
 const rawArgs = parser.parseArgs()
 const [isValid, errorOrArgs] = validate(rawArgs)


### PR DESCRIPTION
I can't push to the `main` branch, so here it is as a PR.
Additional CLI control/tuning knobs I've added for testing:

* interactive mode (suppress Xvfb)
* proxy-server mode (set all the magic CLI args for a SOCKS5 proxy when launching the browser)
* user-agent override option
* extra-arguments option (useful for triggering non-standard features of custom browser builds via CLI args)

