### PR TITLE
Allow using pagegraph-crawl as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ pagegraph-crawl
 ===
 
 Command line tool for crawling with PageGraph.  It does not include a
-PageGraph enabled build though; you'll need to bring your own or
-wait a few days until we start providing our own.
+PageGraph enabled build though; you can point it at the latest Nightly
+version of Brave.
 
 Usage
 ---
@@ -20,7 +20,7 @@ Optional arguments:
   -h, --help            Show this help message and exit.
   -v, --version         Show program's version number and exit.
   -b BINARY, --binary BINARY
-                        Path to the PageGraph enabled build of Brave.
+                        Path to the PageGraph-enabled build of Brave.
   -o OUTPUT, --output OUTPUT
                         Path to write graphs to.
   -u URL [URL ...], --url URL [URL ...]
@@ -39,9 +39,3 @@ Optional arguments:
   --debug {none,debug,verbose}
                         Print debugging information. Default: none.
 ```
-
-Developing
----
-If you're editing / developing please make sure things `npm run lint` cleanly,
-and `num run build` before pushing, to make sure `./built` stays in sync
-with `./src`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "pagegraph-crawl",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "MPL-2.0",
       "dependencies": {
         "@supercharge/promise-pool": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "pagegraph-crawl",
   "version": "1.0.0",
-  "description": "",
+  "description": "CLI for crawling with PageGraph.",
   "main": "built/crawl.js",
   "scripts": {
-    "lint": "node ./node_modules/standardx/bin/cmd.js src/**/*.ts src/*.ts",
-    "lint:fix": "node ./node_modules/standardx/bin/cmd.js --fix src/**/*.ts src/*.ts",
-    "build": "node ./node_modules/typescript/bin/tsc",
+    "lint": "standardx src/**/*.ts src/*.ts",
+    "lint:fix": "standardx --fix src/**/*.ts src/*.ts",
+    "build": "tsc",
+    "postinstall": "npm run build",
     "crawl": "node ./built/run.js"
   },
   "type": "module",


### PR DESCRIPTION
1. If `pagegraph-crawl` is used as a dependency in npm, we can't run scripts in `node_modules` because the `node_modules` directory structure is [non-deterministic](https://npm.github.io/how-npm-works-docs/npm3/non-determinism.html). So just call the binaries for `tsc` and `standardx` in `"scripts"`.
2. Add a `postinstall` build step to compile typescript automatically so the built scripts can be used when `pagegraph-crawl` is used as a dependency.
3. Given that we no longer keep `built/` in git, remove that documentation.